### PR TITLE
dependencycheck.yml runs on python 3.10

### DIFF
--- a/.github/workflows/dependencycheck.yml
+++ b/.github/workflows/dependencycheck.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
       
       - name: Install poetry
         run: |


### PR DESCRIPTION
Included step to specify python 3.10, got it from here https://github.com/actions/setup-python
Closes #39 